### PR TITLE
change `ctrl+num` hotkeys to `alt+num`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -122,3 +122,5 @@ dmypy.json
 .DS_Store
 
 .yarn/
+
+yarn.lock

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ It was have preferred not to re-use the term 'split', because in jupyterlab _spl
 
 there is no button (yet) in this extension to do the equivalent of the former 'split-cell' thing, you can use
 
-- either keyboard Ctrl-\ Ctrl-1 Ctrl-2 (meaning you want to use 1 / 2 of the horizontal space)
+- either keyboard `Alt+1, Alt+2` (meaning you want to use 1 / 2 of the horizontal space)
 - or type `gridwidth` in the Palette and pick 1/2
 - or command `gridwidth:toggle-1-2`
 - that you can bind to a keyboard shortcut of your choice
@@ -31,9 +31,9 @@ there is no button (yet) in this extension to do the equivalent of the former 's
 
 ### keyboard shortcuts
 
-- `Ctrl-\ Ctrl-1 Ctrl-2` and so on; these will toggle the corresponding tag, and
+- `Alt+1, Alt+2` and so on; these will toggle the corresponding tag, and
   remove any other tag that might be present
-- `Ctrl-\ Ctrl-0` to reset to full width
+- `Alt+0` to reset to full width
 
 ### available tags:
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
       palette.addItem({ command, category: 'gridwidth' })
       app.commands.addKeyBinding({
         command,
-        keys: ['Ctrl \\', `Ctrl ${num}`, `Ctrl ${den}`],
+        keys: [`Alt ${num}`, `Alt ${den}`],
         selector: '.jp-Notebook'
       })
     }
@@ -85,7 +85,7 @@ const plugin: JupyterFrontEndPlugin<void> = {
     palette.addItem({ command, category: 'gridwidth' })
     app.commands.addKeyBinding({
       command,
-      keys: ['Ctrl \\', 'Ctrl 0'],
+      keys: ['Alt 0'],
       selector: '.jp-Notebook'
     })
   }


### PR DESCRIPTION
I have changed `ctrl+num` hotkeys to `alt+num`. It solves the `ctrl+num` conflicts on windows chrome.
I tested it locally. Looks working fine.
Now only need to press `alt+1  alt+2` or `alt +1 +2` to grid the cell half width, also easy to use.